### PR TITLE
[FIX] Remove the `--with-bots` switch from users (#16)

### DIFF
--- a/matrixctl/users.py
+++ b/matrixctl/users.py
@@ -59,8 +59,9 @@ def users(arg: Namespace) -> int:
     This function generates and prints a table of matrix user accounts.
     The table can be modified.
 
-    If you want guests in the table use the ``--with-guests`` switch.
-    If you want deactivated user in the table use the ``--with-deactivated`` switch.
+    * If you want guests in the table use the ``--with-guests`` switch.
+    * If you want deactivated user in the table use the ``--with-deactivated``
+      switch.
 
     **Example**
 


### PR DESCRIPTION
The users `--with-bots' switch was inconsistent when using LDAP users and must be removed. (Fix #16)