### PR TITLE
Run ansible with ansible-runner

### DIFF
--- a/matrixctl/check.py
+++ b/matrixctl/check.py
@@ -21,7 +21,7 @@ from argparse import Namespace
 from argparse import _SubParsersAction as SubParsersAction
 from logging import debug
 
-from .handlers.ansible import Ansible
+from .handlers.ansible import ansible_run
 from .handlers.toml import TOML
 
 
@@ -39,9 +39,9 @@ def subparser_check(subparsers: SubParsersAction) -> None:
 def check(_: Namespace) -> int:
     debug("check")
     with TOML() as toml:
-        with Ansible(toml.get(("SYNAPSE", "Path"))) as ansible:
-            ansible.tags = ("check",)
-            ansible.run_playbook()
+        ansible_run(
+            playbook=toml.get(("ANSIBLE", "Playbook")), tags=("check",)
+        )
 
         return 0
 

--- a/matrixctl/deploy.py
+++ b/matrixctl/deploy.py
@@ -16,15 +16,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-import sys
-
 from argparse import ArgumentParser
 from argparse import Namespace
 from argparse import _SubParsersAction as SubParsersAction
 from logging import debug
-from logging import error
 
-from .handlers.ansible import Ansible
+from .handlers.ansible import ansible_run
 from .handlers.toml import TOML
 
 
@@ -36,68 +33,17 @@ def subparser_deploy(subparsers: SubParsersAction) -> None:
     parser: ArgumentParser = subparsers.add_parser(
         "deploy", help="Provision and deploy"
     )
-    parser.add_argument(
-        "-s",
-        "--synapse",
-        action="store_true",
-        help="Deploy only the synapse playbook",
-    )
-    parser.add_argument(
-        "-a",
-        "--ansible",
-        action="store_true",
-        help="Deploy only your own playbook",
-    )
     parser.set_defaults(func=deploy)
 
 
 def deploy(arg: Namespace) -> int:
-    """Deploy the ansible playbook.
-
-    **Contol logic**
-
-    a = ta  (TOML Ansible)
-    b = ts  (TOML SYNAPSE)
-    A = arg.ansible
-    B = arg.synapse
-
-    Empirical:
-    Ansible = a/A/B + aA
-    Synapse = b/A/B + bB
-    Error = /a/b + /aA + /bB
-
-    Optimized (factored SOP):
-
-    Ansible = a(/A/B + A)
-    Synapse = b(/A/B + B)
-    Error = /b(B + /a) + /aA
-    """
+    """Deploy the ansible playbook."""
     debug("deploy")
     with TOML() as toml:
-        # make them shorter
-        ta: bool = toml.get(("ANSIBLE", "Path"), True) is not None
-        ts: bool = toml.get(("SYNAPSE", "Path"), True) is not None
-
-        if not ts and (arg.synapse or not ta) or not ta and arg.ansible:
-            error(
-                "To be able to use the deploy feature, you need to have "
-                "At least your own Ansible playbook configuration in the "
-                "MatrixCtl config file or the "
-                "spantaleev/matrix-docker-ansible-deploy "
-                "playbook"
-            )
-            sys.exit(1)
-
-        if ta and (not arg.ansible and not arg.synape or arg.ansible):
-            with Ansible(toml.get(("ANSIBLE", "Path"))) as ansible:
-                ansible.tags = toml.get(("ANSIBLE", "DeployTags"))
-                ansible.ansible_cfg_path = toml.get(("ANSIBLE", "Cfg"))
-                ansible.run_playbook()
-
-        if ts and (not arg.ansible and not arg.synapse or arg.synapse):
-            with Ansible(toml.get(("SYNAPSE", "Path"))) as ansible:
-                ansible.tags = ("setup-all",)
-                ansible.run_playbook()
+        ansible_run(
+            playbook=toml.get(("ANSIBLE", "Playbook")),
+            tags=("setup-all",),
+        )
 
         return 0
 

--- a/matrixctl/handlers/ansible.py
+++ b/matrixctl/handlers/ansible.py
@@ -16,110 +16,37 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-import json
-import os
-import subprocess
-
 from logging import debug
 from pathlib import Path
-from types import TracebackType
 from typing import Dict
-from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Type
-from typing import Union
+from typing import Tuple
 
-from matrixctl.typing import JsonDict
+import ansible_runner
 
 
 __author__: str = "Michael Sasser"
 __email__: str = "Michael@MichaelSasser.org"
 
 
-# ToDO: __slots__
-class Ansible:
-    def __init__(
-        self, path: Union[Path, str], playbook: str = "setup.yml"
-    ) -> None:
-        self.path: Path = Path(path)
+# ToDo: Make async to get debug output while running
+def ansible_run(
+    playbook: Path,
+    tags: Optional[Tuple[str, ...]] = None,
+    extra_vars: Optional[Dict[str, str]] = None,
+) -> None:
+    runner = ansible_runner.run(
+        playbook=playbook,
+        tags=tags,
+        extravars=extra_vars,
+    )
 
-        assert isinstance(playbook, str)
-
-        self.playbook: str = playbook
-        self.__ansible_cfg_path: Optional[str] = None
-        self.__cmd: Dict[str, str] = {  # Defaults are already in here
-            "inventory": str(self.path / "inventory/hosts"),
-        }
-
-    def _inventory_path(self, path: Path) -> None:
-        assert isinstance(path, Path)
-        self.__cmd["inventory"] = str(path)
-
-    def _tags(self, tags: Iterable[str]) -> None:
-        assert isinstance(tags, Iterable)
-        self.__cmd["tags"] = ",".join(tags)  # e.g. tag1,tag2,...,tagn
-
-    def _extra_vars(self, extra_vars: JsonDict) -> None:
-        self.__cmd["extra-vars"] = json.dumps(extra_vars).replace(" ", "")
-
-    def _ansible_cfg_path(self, path: Path) -> None:
-        assert isinstance(path, str)
-        self.__ansible_cfg_path = path
-
-    inventory_path = property(fset=_inventory_path)
-    tags = property(fset=_tags)
-    extra_vars = property(fset=_extra_vars)
-    ansible_cfg_path = property(fset=_ansible_cfg_path)
-
-    def run_playbook(self) -> None:
-        # Build the command
-        cmd: List[str] = ["ansible-playbook"]
-
-        for k in self.__cmd:
-            cmd.append(f"--{k}={self.__cmd[k]}")
-
-        cmd.append(str(self.path / self.playbook))
-
-        # Debug output of the command
-        debug(f"Ansible command:           {cmd}")
-        debug(f"Ansible assembled command: {' '.join(cmd)}")
-
-        # Add ansible.cfg to ENV
-
-        if self.__ansible_cfg_path is not None:
-            os.environ["ANSIBLE_CONFIG"] = self.__ansible_cfg_path
-
-        # Run command
-        subprocess.run(cmd, check=True)
-
-        # Delete ansible.cfg from ENV
-
-        if self.__ansible_cfg_path is not None:
-            del os.environ["ANSIBLE_CONFIG"]
-
-    def __enter__(self) -> Ansible:
-        """Use the class with the ``with`` statement`` statement.
-
-        This is currently not really needed, but unifies the way handlers are
-        used.
-        """
-
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> None:
-        """Use the class with the ``with`` statement`` statement.
-
-        This is currently not really needed, but unifies the way handlers are
-        used.
-        """
-
-        return
+    # debugging output
+    debug("Runner status")
+    debug(f"{runner.status}: {runner.rc}")
+    for host_event in runner.events:
+        debug(host_event["event"])
+    debug(f"Final status: {runner.stats}")
 
 
 # vim: set ft=python :

--- a/matrixctl/maintenance.py
+++ b/matrixctl/maintenance.py
@@ -21,7 +21,7 @@ from argparse import Namespace
 from argparse import _SubParsersAction as SubParsersAction
 from logging import debug
 
-from .handlers.ansible import Ansible
+from .handlers.ansible import ansible_run
 from .handlers.toml import TOML
 
 
@@ -40,12 +40,13 @@ def maintenance(_: Namespace) -> int:
     debug("maintenance")
 
     with TOML() as toml:
-        with Ansible(toml.get(("SYNAPSE", "Path"))) as ansible:
-            ansible.tags = (
+        ansible_run(
+            playbook=toml.get(("ANSIBLE", "Playbook")),
+            tags=(
                 "run-postgres-vacuum",
                 "start",
-            )
-            ansible.run_playbook()
+            ),
+        )
 
     return 0
 

--- a/matrixctl/start.py
+++ b/matrixctl/start.py
@@ -21,7 +21,7 @@ from argparse import Namespace
 from argparse import _SubParsersAction as SubParsersAction
 from logging import debug
 
-from .handlers.ansible import Ansible
+from .handlers.ansible import ansible_run
 from .handlers.toml import TOML
 
 
@@ -47,10 +47,7 @@ def start(_: Namespace) -> int:
     debug("start")
 
     with TOML() as toml:
-        with Ansible(toml.get(("SYNAPSE", "Path"))) as ansible:
-            ansible.tags = ("start",)
-            ansible.run_playbook()
-
+        ansible_run(toml.get(("SYNAPSE", "Path")), tags=("start",))
         return 0
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,21 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "ansible-runner"
+version = "1.4.6"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pexpect = ">=4.5"
+psutil = "*"
+python-daemon = "*"
+PyYAML = "*"
+six = "*"
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -209,7 +224,7 @@ name = "docutils"
 version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
@@ -375,6 +390,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "lockfile"
+version = "0.12.2"
+description = "Platform-independent file locking module"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "markupsafe"
 version = "1.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -491,6 +514,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
@@ -516,6 +550,25 @@ nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
 virtualenv = ">=20.0.8"
+
+[[package]]
+name = "psutil"
+version = "5.7.3"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
+
+[[package]]
+name = "ptyprocess"
+version = "0.6.0"
+description = "Run a subprocess in a pseudo terminal"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "py"
@@ -655,6 +708,22 @@ py = ">=1.8.2"
 toml = "*"
 
 [[package]]
+name = "python-daemon"
+version = "2.2.4"
+description = "Library to implement a well-behaved Unix daemon process."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["coverage", "docutils", "mock (>=1.3)", "testscenarios (>=0.4)", "testtools", "unittest2 (>=0.5.1)"]
+
+[package.dependencies]
+docutils = "*"
+lockfile = ">=0.10"
+setuptools = "*"
+
+[[package]]
 name = "python-jsonrpc-server"
 version = "0.4.0"
 description = "JSON RPC 2.0 server library"
@@ -742,7 +811,7 @@ python-versions = "*"
 name = "pyyaml"
 version = "5.3.1"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -1057,12 +1126,16 @@ docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autodoc-typehints", "sphinxcontrib
 [metadata]
 lock-version = "1.0"
 python-versions = "^3.8"
-content-hash = "c5e30cf49d98e46881f89a35f643a3a58955991af94dcc2dfe1b4b65c494a6bf"
+content-hash = "4485631b62b7c89898ee5b44b7146a69c9cb9ec034a69d6372c2cee92e265a39"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+ansible-runner = [
+    {file = "ansible-runner-1.4.6.tar.gz", hash = "sha256:53605de32f7d3d3442a6deb8937bf1d9c1f91c785e3f71003d22c3e63f85c71d"},
+    {file = "ansible_runner-1.4.6-py3-none-any.whl", hash = "sha256:0744642cff32d23310b3a5f5aae23d07bea1051724e66b27f9bbccefec8427dd"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -1286,6 +1359,10 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
 ]
+lockfile = [
+    {file = "lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"},
+    {file = "lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"},
+]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
     {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
@@ -1388,6 +1465,10 @@ pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
+pexpect = [
+    {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
+    {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
@@ -1395,6 +1476,23 @@ pluggy = [
 pre-commit = [
     {file = "pre_commit-2.9.2-py2.py3-none-any.whl", hash = "sha256:949b13efb7467ae27e2c8f9e83434dacf2682595124d8902554a4e18351e5781"},
     {file = "pre_commit-2.9.2.tar.gz", hash = "sha256:e31c04bc23741194a7c0b983fe512801e151a0638c6001c49f2bd034f8a664a1"},
+]
+psutil = [
+    {file = "psutil-5.7.3-cp27-none-win32.whl", hash = "sha256:1cd6a0c9fb35ece2ccf2d1dd733c1e165b342604c67454fd56a4c12e0a106787"},
+    {file = "psutil-5.7.3-cp27-none-win_amd64.whl", hash = "sha256:e02c31b2990dcd2431f4524b93491941df39f99619b0d312dfe1d4d530b08b4b"},
+    {file = "psutil-5.7.3-cp35-cp35m-win32.whl", hash = "sha256:56c85120fa173a5d2ad1d15a0c6e0ae62b388bfb956bb036ac231fbdaf9e4c22"},
+    {file = "psutil-5.7.3-cp35-cp35m-win_amd64.whl", hash = "sha256:fa38ac15dbf161ab1e941ff4ce39abd64b53fec5ddf60c23290daed2bc7d1157"},
+    {file = "psutil-5.7.3-cp36-cp36m-win32.whl", hash = "sha256:01bc82813fbc3ea304914581954979e637bcc7084e59ac904d870d6eb8bb2bc7"},
+    {file = "psutil-5.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:6a3e1fd2800ca45083d976b5478a2402dd62afdfb719b30ca46cd28bb25a2eb4"},
+    {file = "psutil-5.7.3-cp37-cp37m-win32.whl", hash = "sha256:fbcac492cb082fa38d88587d75feb90785d05d7e12d4565cbf1ecc727aff71b7"},
+    {file = "psutil-5.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:5d9106ff5ec2712e2f659ebbd112967f44e7d33f40ba40530c485cc5904360b8"},
+    {file = "psutil-5.7.3-cp38-cp38-win32.whl", hash = "sha256:ade6af32eb80a536eff162d799e31b7ef92ddcda707c27bbd077238065018df4"},
+    {file = "psutil-5.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:2cb55ef9591b03ef0104bedf67cc4edb38a3edf015cf8cf24007b99cb8497542"},
+    {file = "psutil-5.7.3.tar.gz", hash = "sha256:af73f7bcebdc538eda9cc81d19db1db7bf26f103f91081d780bbacfcb620dee2"},
+]
+ptyprocess = [
+    {file = "ptyprocess-0.6.0-py2.py3-none-any.whl", hash = "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"},
+    {file = "ptyprocess-0.6.0.tar.gz", hash = "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"},
 ]
 py = [
     {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
@@ -1457,6 +1555,10 @@ pyreadline = [
 pytest = [
     {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
     {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
+]
+python-daemon = [
+    {file = "python-daemon-2.2.4.tar.gz", hash = "sha256:57c84f50a04d7825515e4dbf3a31c70cc44414394a71608dee6cfde469e81766"},
+    {file = "python_daemon-2.2.4-py2.py3-none-any.whl", hash = "sha256:a0d5dc0b435a02c7e0b401e177a7c17c3f4c7b4e22e2d06271122c8fec5f8946"},
 ]
 python-jsonrpc-server = [
     {file = "python-jsonrpc-server-0.4.0.tar.gz", hash = "sha256:62c543e541f101ec5b57dc654efc212d2c2e3ea47ff6f54b2e7dcb36ecf20595"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ sphinx_rtd_theme = { version = "^0.5.0", optional = true  }
 sphinx-autodoc-typehints = { version = "^1.11.1", optional = true }
 sphinxcontrib-programoutput = { version = "^0.16", optional = true }
 toml = "^0.10.2"
+ansible-runner = "^1.4.6"
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autodoc-typehints", "sphinxcontrib-programoutput"]
@@ -104,6 +105,7 @@ known_third_party = [
     "sphinx_rtd_theme",
     "git",
     "toml",
+    "ansible_runner",
 ]
 
 [tool.flake8]


### PR DESCRIPTION
**Remove**

 - [x] The option to run multiple playbooks with `matrixctl`. The user should use `- import_playbook: /PathTo/matrix-docker-ansible-deploy/setup.yml` in an own playbook. (Fix #19)

**Add**

- [x] The ansible handler uses `ansible-runner` instead of the `subprocess` module
