### PR TITLE
docs: fix commandline example

### DIFF
--- a/docs/source/commandline_tool.rst
+++ b/docs/source/commandline_tool.rst
@@ -1,5 +1,5 @@
 MatrixCtl as a pure commandline tool. You can use it as package, if you like,
 but breaking changes may introduced, even in a minor change.
 
-.. program-output:: ../../app.py --help | sed 's/app\.py/matrixctl/g'
+.. program-output:: python ../../matrixctl --help
    :shell:

--- a/news/68.docs
+++ b/news/68.docs
@@ -1,0 +1,1 @@
+Fixed the commandline tool example in the docs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ template = "news/templates/default.rst"
   showcontent = true
 
   [[tool.towncrier.type]]
-  directory = "doc"
+  directory = "docs"
   name = "Improved Documentation"
   showcontent = true
 


### PR DESCRIPTION
Fix the commandline example in the docs, which shows the output of `matrixctl --help`. (fixes #68)
