### PR TITLE
docs: remove program name from changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,8 @@ This is the changelog of MatrixCtl. You can find the issue tracker on
 
 .. towncrier release notes start
 
-MatrixCtl 0.8.6 (2021-04-17)
-============================
+0.8.6 (2021-04-17)
+==================
 
 Features & Improvements
 -----------------------

--- a/news/79.docs
+++ b/news/79.docs
@@ -1,0 +1,1 @@
+Removed the program name from every title of the changelog. We now only use the version number and the date.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,8 +147,9 @@ package_dir = "matrixctl"
 filename = "CHANGELOG.rst"
 issue_format = "`#{issue} <https://github.com/MichaelSasser/matrixctl/issues/{issue}>`_"
 directory = "news/"
-name = "MatrixCtl"
-title_format = "{name} {version} ({project_date})"
+top_line = false
+# name = "MatrixCtl"
+title_format = "{version} ({project_date})"  # {name}
 start_string = ".. towncrier release notes start"
 all_bullets = true  # make all fragments bullet points
 wrap = true  # Wrap text to 79 characters
@@ -165,7 +166,7 @@ template = "news/templates/default.rst"
   showcontent = true
 
   [[tool.towncrier.type]]
-  directory = "doc"
+  directory = "docs"
   name = "Improved Documentation"
   showcontent = true
 


### PR DESCRIPTION
Remove the program name from every title of the changelog. (fixes #79)
*We now only use the version number and the date.*
