### PR TITLE
Move docs back to rtd

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,9 +164,9 @@ repos:
     hooks:
       - id: vulture
 
-  # PEP 585 Upgrade (Type Hints)
-  - repo: https://github.com/sondrelg/pep585-upgrade
-    # Use the sha / tag you want to point at
-    rev: 'ab1595ee0aa8823dcda1f0bd95b2c194fcd5362b'
-    hooks:
-    - id: upgrade-type-hints
+  # # PEP 585 Upgrade (Type Hints)
+  # - repo: https://github.com/sondrelg/pep585-upgrade
+  #   # Use the sha / tag you want to point at
+  #   rev: 'ab1595ee0aa8823dcda1f0bd95b2c194fcd5362b'
+  #   hooks:
+  #   - id: upgrade-type-hints

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,7 +24,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,32 @@
+# matrixctl
+# Copyright (c) 2021  Michael Sasser <Michael@MichaelSasser.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+---
+
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+formats: all
+
+python:
+  version: 3.9
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -265,7 +265,7 @@ Features & Improvements
 Bugfixes
 --------
 
--  SSH handler logs an error if unable to connect (`#7
+- SSH handler logs an error if unable to connect (`#7
   <https://github.com/MichaelSasser/matrixctl/issues/7>`_)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -128,3 +128,339 @@ Miscellaneous
   <https://github.com/MichaelSasser/matrixctl/releases>`_. (`#61
   <https://github.com/MichaelSasser/matrixctl/issues/61>`_)
 
+
+0.8.5 (2021-02-24)
+==================
+
+Bugfixes
+--------
+
+- Add the new ``serve-notice`` feature.
+
+
+0.8.4 (2021-02-24)
+==================
+
+.. note:: This version of MatrixCtl has not been released.
+
+
+0.8.3 (2021-02-24)
+==================
+
+.. note:: This version of MatrixCtl has not been released.
+
+
+0.8.2 (2021-02-24)
+==================
+
+.. note:: This version of MatrixCtl has not been released.
+
+Features & Improvements
+-----------------------
+
+- feature ``upload`` which makes it possible to upload files and images. It returns the ``mxc://`` uri.
+- feature ``server-notice``.
+
+Miscellaneous
+-------------
+
+- Changed docs to classic python theme.
+
+
+0.8.1 (2020-12-02)
+==================
+
+Behavior & Breaking Changes
+---------------------------
+
+- The ``update`` command now uses config: ``[SYNAPSE]`` -> ``Playbook`` instead of ``[SYNAPSE]`` -> ``Path``
+
+Features & Improvements
+-----------------------
+
+- Add missing ``[SYNAPSE]`` (config file) documentation.
+
+
+0.8.0 (2020-12-02)
+==================
+
+Behavior & Breaking Changes
+---------------------------
+
+- The option to run multiple playbooks with matrixctl. The user should use - import_playbook: /PathTo/matrix-docker-ansible-deploy/setup.yml in an own playbook. (`#20
+  <https://github.com/MichaelSasser/matrixctl/issues/20>`_)(`#21
+  <https://github.com/MichaelSasser/matrixctl/issues/21>`_)
+
+Features & Improvements
+-----------------------
+
+- The ``ansible`` handler now uses ``ansible-runner`` instead of ``subprocess`` (`#20
+  <https://github.com/MichaelSasser/matrixctl/issues/20>`_)(`#21
+  <https://github.com/MichaelSasser/matrixctl/issues/21>`_)
+- The ``api`` handler now gives the user a hint, when the admin api is disabled.
+
+
+0.7.0 (2020-09-25)
+==================
+
+Behavior & Breaking Changes
+---------------------------
+
+- Removed the ``--with-bots``, "bots" are now shown by default (`#15
+  <https://github.com/MichaelSasser/matrixctl/issues/15>`_)
+
+Bugfixes
+--------
+
+- Fixed the deploy control logic (`#18
+  <https://github.com/MichaelSasser/matrixctl/issues/18>`_)
+
+
+0.6.3 (2020-09-17)
+==================
+
+Features & Improvements
+-----------------------
+
+- With the help of two args it is possible to deploy the two playbooks independently:
+  - ``-s``/``--synapse``: Only deploy the synapse playbook,
+  - ``-a``/``--ansible``: Only deploy your own playbook.
+
+
+0.6.2 (2020-09-16)
+==================
+
+Bugfixes
+--------
+
+- It is now possible to deploy, when only one of ``[ANSIBLE]`` or ``[SYNAPSE]`` are configured.
+
+
+0.6.1 (2020-06-02)
+==================
+
+Features & Improvements
+-----------------------
+
+- If the access-token has changed or is wrong, MatrixCtl now throws a specific error, which tells the user, what went wrong. (`#12
+  <https://github.com/MichaelSasser/matrixctl/issues/12>`_)
+- Replace the assertions from the API handler with proper ``TypeError``.
+
+
+0.6.0 (2020-05-12)
+==================
+
+Behavior & Breaking Changes
+---------------------------
+
+- Changed ``users --no-bots`` or ``users -b`` to ``users --with-bots`` or ``users -b``
+- Changed ``users --guests`` or ``users -g`` to ``users --with-guests`` or ``users -g``
+
+Features & Improvements
+-----------------------
+
+- ``users --with-deactivated`` or ``users -d`` (`#2
+  <https://github.com/MichaelSasser/matrixctl/issues/2>`_)
+
+Bugfixes
+--------
+
+-  SSH handler logs an error if unable to connect (`#7
+  <https://github.com/MichaelSasser/matrixctl/issues/7>`_)
+
+
+0.5.0 (2020-04-30)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+Behavior & Breaking Changes
+---------------------------
+
+- Fixed typo in the ``maintenance`` command.
+
+Removals & Deprecations
+-----------------------
+
+- Removed ``run-postgres-synapse-janitor`` from maintenance because it may destroy the DB (`#8
+  <https://github.com/MichaelSasser/matrixctl/issues/8>`_)(`#465 (spantaleev/matrix-docker-ansible-deploy)
+  <https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/465>`_)
+
+
+0.4.0 (2020-04-22)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+Behavior & Breaking Changes
+---------------------------
+
+- ``rooms`` submodule: Changed argument ``--order_by_size`` to
+  ``--order-by-size``.
+
+Features & Improvements
+-----------------------
+
+- Add the ``version`` command.
+- Add the ``delroom`` command.
+- Add more debug output to the API handler (``params``, ``data``, ``method`` and censored
+  ``headers``)
+
+
+0.3.2 (2020-04-21)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+Features & Improvements
+-----------------------
+
+- Add the ``rooms`` command.
+
+
+0.3.1 (2020-04-21)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+.. note:: This version of MatrixCtl has not been released.
+
+
+0.3.0 (2020-04-20)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+.. note:: No significant changes to the Project.
+
+Project restructured.
+
+
+0.2.2 (2020-04-13)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+
+Features & Improvements
+-----------------------
+
+- Added docs to the Project (``gh-pages`` branch).
+
+Bugfixes
+--------
+
+- ``matixctl adduser --ansible``. MatrixCtl was not able to create a user with the ``--ansible`` argument.
+
+
+0.2.1 (2020-04-13)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+.. note:: This version of MatrixCtl has not been released.
+
+
+0.2.0 (2020-04-12)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+Behavior & Breaking Changes
+---------------------------
+
+- The command ``list-user`` has been renamed to ``users``.
+
+Features & Improvements
+-----------------------
+
+- Add the command ``user``.
+
+
+0.1.4 (2020-04-10)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+Features & Improvements
+-----------------------
+
+- Add the command ``start``.
+- Add the command ``restart`` (alias for ``start``).
+- Add the command ``check``.
+
+
+0.1.3 (2020-04-10)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+Features & Improvements
+-----------------------
+
+- Add the command ``adduser-jitsi``.
+- Add the command ``deluser-jitsi``.
+
+
+0.1.2 (2020-04-07)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+**First official release.**
+
+Features & Improvements
+-----------------------
+
+- Add the command ``list-users``.
+
+
+0.1.1 (2020-04-07)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+.. note:: No significant changes to the Project.
+
+
+Trivial Changes
+---------------
+
+- Fixed GitHub Wokflow.
+
+
+0.1.0 (2020-04-07)
+==================
+
+.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
+          **do not** use the ``maintenance`` command for any MatrixCtl version
+          below 0.5.0!
+
+.. note:: No significant changes to the Project.
+
+**Internal Release**
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -272,9 +272,9 @@ Bugfixes
 0.5.0 (2020-04-30)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 Behavior & Breaking Changes
 ---------------------------
@@ -292,9 +292,9 @@ Removals & Deprecations
 0.4.0 (2020-04-22)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 Behavior & Breaking Changes
 ---------------------------
@@ -314,9 +314,9 @@ Features & Improvements
 0.3.2 (2020-04-21)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 Features & Improvements
 -----------------------
@@ -327,9 +327,9 @@ Features & Improvements
 0.3.1 (2020-04-21)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 .. note:: This version of MatrixCtl has not been released.
 
@@ -337,9 +337,9 @@ Features & Improvements
 0.3.0 (2020-04-20)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 .. note:: No significant changes to the Project.
 
@@ -349,10 +349,9 @@ Project restructured.
 0.2.2 (2020-04-13)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
-
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 Features & Improvements
 -----------------------
@@ -368,9 +367,9 @@ Bugfixes
 0.2.1 (2020-04-13)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 .. note:: This version of MatrixCtl has not been released.
 
@@ -378,9 +377,9 @@ Bugfixes
 0.2.0 (2020-04-12)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 Behavior & Breaking Changes
 ---------------------------
@@ -396,9 +395,9 @@ Features & Improvements
 0.1.4 (2020-04-10)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 Features & Improvements
 -----------------------
@@ -411,9 +410,9 @@ Features & Improvements
 0.1.3 (2020-04-10)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 Features & Improvements
 -----------------------
@@ -425,9 +424,9 @@ Features & Improvements
 0.1.2 (2020-04-07)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 **First official release.**
 
@@ -440,9 +439,10 @@ Features & Improvements
 0.1.1 (2020-04-07)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
+
 
 .. note:: No significant changes to the Project.
 
@@ -456,9 +456,9 @@ Trivial Changes
 0.1.0 (2020-04-07)
 ==================
 
-.. note:: Since the ``synapse-janitor`` is not safe to use anymore, please
-          **do not** use the ``maintenance`` command for any MatrixCtl version
-          below 0.5.0!
+.. warning:: Since the ``synapse-janitor`` is not safe to use anymore, please
+             **do not** use the ``maintenance`` command for any MatrixCtl
+             version below 0.5.0!
 
 .. note:: No significant changes to the Project.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,5 @@
-Changelog
-=========
+*********
+CHANGELOG
+*********
 
 .. include::  ../../CHANGELOG.rst

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,1 +1,4 @@
+Changelog
+=========
+
 .. include::  ../../CHANGELOG.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,11 +14,14 @@ import os
 import sys
 
 from datetime import date
+from pathlib import Path
 
-from pkg_resources import get_distribution
+from single_source import get_version
 
 
-__version__: str = get_distribution("matrixctl").version
+__version__: str = (
+    get_version(__name__, Path(__file__).parent.parent) or "Unknown"
+)
 
 sys.path.insert(0, os.path.abspath("../"))
 sys.path.insert(0, os.path.abspath("../.."))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,7 @@ exclude_patterns: List[str] = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme: str = "sphinx-rtd-theme"
+html_theme: str = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ import sys
 
 from datetime import date
 from pathlib import Path
+from typing import List
 
 from single_source import get_version
 
@@ -42,7 +43,7 @@ release: str = __version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions: list[str] = [
+extensions: List[str] = [
     "sphinx.ext.autodoc",
     "sphinx.ext.mathjax",
     "sphinx_autodoc_typehints",
@@ -56,7 +57,7 @@ extensions: list[str] = [
     "sphinx.ext.inheritance_diagram",
 ]
 
-suppress_warnings: list[str] = ["autosectionlabel.*"]
+suppress_warnings: List[str] = ["autosectionlabel.*"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
@@ -93,12 +94,12 @@ autosummary_generate: bool = True
 autosummary_imported_members: bool = True
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path: list[str] = ["_templates"]
+templates_path: List[str] = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: list[str] = []
+exclude_patterns: List[str] = []
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -110,4 +111,4 @@ html_theme: str = "classic"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path: list[str] = ["_static"]
+html_static_path: List[str] = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,14 +1,23 @@
-# Configuration file for the Sphinx documentation builder.
+# matrixctl
+# Copyright (c) 2020  Michael Sasser <Michael@MichaelSasser.org>
 #
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-# -- Path setup --------------------------------------------------------------
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Use this module to generate the documentation with ``sphinx``."""
+
+# Configuration file for the Sphinx documentation builder.
+# !! This file needs to be compatible with Python 3.8 !!
 
 import os
 import sys
@@ -16,6 +25,8 @@ import sys
 from datetime import date
 from pathlib import Path
 from typing import List
+
+import sphinx_rtd_theme
 
 from single_source import get_version
 
@@ -55,6 +66,7 @@ extensions: List[str] = [
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.inheritance_diagram",
+    "sphinx_rtd_theme",
 ]
 
 suppress_warnings: List[str] = ["autosectionlabel.*"]
@@ -106,7 +118,7 @@ exclude_patterns: List[str] = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme: str = "classic"
+html_theme: str = "sphinx-rtd-theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/contributer_documentation/handlers.rst
+++ b/docs/source/contributer_documentation/handlers.rst
@@ -1,0 +1,62 @@
+..
+   matrixctl
+   Copyright (c) 2021  Michael Sasser <Michael@MichaelSasser.org>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Handlers
+********
+
+TOML
+----
+
+.. automodule:: matrixctl.handlers.toml
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+API
+---
+
+.. automodule:: matrixctl.handlers.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Ansible
+-------
+
+.. automodule:: matrixctl.handlers.ansible
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Git
+---
+
+.. automodule:: matrixctl.handlers.git
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+SSH
+---
+
+.. automodule:: matrixctl.handlers.ssh
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+..
+   vim: set ft=rst :

--- a/docs/source/contributer_documentation/helpers.rst
+++ b/docs/source/contributer_documentation/helpers.rst
@@ -1,0 +1,39 @@
+..
+   matrixctl
+   Copyright (c) 2021  Michael Sasser <Michael@MichaelSasser.org>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Helpers
+*******
+
+
+Print
+-----
+
+.. automodule:: matrixctl.print_helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Password
+--------
+
+.. automodule:: matrixctl.password_helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+..
+   vim: set ft=rst :

--- a/docs/source/contributer_documentation/index.rst
+++ b/docs/source/contributer_documentation/index.rst
@@ -1,0 +1,35 @@
+..
+   matrixctl
+   Copyright (c) 2021  Michael Sasser <Michael@MichaelSasser.org>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*************************
+Contributer Documentation
+*************************
+
+**<Placeholder Contributing to MatrixCtl>**
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Technical Documentation:
+
+   handlers
+   helpers
+   typing_and_errors
+   the_application
+   subcommands
+
+..
+   vim: set ft=rst :

--- a/docs/source/contributer_documentation/subcommands.rst
+++ b/docs/source/contributer_documentation/subcommands.rst
@@ -1,10 +1,22 @@
-*************************
-Contributer Documentation
-*************************
+..
+   matrixctl
+   Copyright (c) 2021  Michael Sasser <Michael@MichaelSasser.org>
 
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Subcommands
-===========
+***********
 
 
 adduser
@@ -151,100 +163,5 @@ get-event
    :undoc-members:
    :show-inheritance:
 
-Helpers
-=======
-
-
-Print
------
-
-.. automodule:: matrixctl.print_helpers
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Password
---------
-
-.. automodule:: matrixctl.password_helpers
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Typing and Errors
-=================
-
-
-Typing
-------
-
-.. automodule:: matrixctl.typing
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Errors
-------
-
-.. automodule:: matrixctl.errors
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-The Application
-===============
-
-
-Application
------------
-
-.. automodule:: matrixctl.__main__
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Handlers
-========
-
-TOML
-----
-
-.. automodule:: matrixctl.handlers.toml
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-API
----
-
-.. automodule:: matrixctl.handlers.api
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Ansible
--------
-
-.. automodule:: matrixctl.handlers.ansible
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Git
----
-
-.. automodule:: matrixctl.handlers.git
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-SSH
----
-
-.. automodule:: matrixctl.handlers.ssh
-   :members:
-   :undoc-members:
-   :show-inheritance:
+..
+   vim: set ft=rst :

--- a/docs/source/contributer_documentation/the_application.rst
+++ b/docs/source/contributer_documentation/the_application.rst
@@ -1,0 +1,31 @@
+..
+   matrixctl
+   Copyright (c) 2021  Michael Sasser <Michael@MichaelSasser.org>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+The Application
+***************
+
+
+Application
+-----------
+
+.. automodule:: matrixctl.__main__
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+..
+   vim: set ft=rst :

--- a/docs/source/contributer_documentation/typing_and_errors.rst
+++ b/docs/source/contributer_documentation/typing_and_errors.rst
@@ -1,0 +1,39 @@
+..
+   matrixctl
+   Copyright (c) 2021  Michael Sasser <Michael@MichaelSasser.org>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Typing and Errors
+*****************
+
+
+Typing
+------
+
+.. automodule:: matrixctl.typing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Errors
+------
+
+.. automodule:: matrixctl.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+..
+   vim: set ft=rst :

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,11 +5,12 @@ MatrixCtl documentation
 
 .. toctree::
    :maxdepth: 2
+   :titlesonly:
    :caption: Contents:
 
    installation
    getting_started/index
-   matrixctl
+   contributer_documentation/index
    changelog
 
 Branching Model

--- a/news/69.feature
+++ b/news/69.feature
@@ -1,0 +1,1 @@
+The docks have moved back to (`https://matrixctl.readthedocs.io/ <https://matrixctl.readthedocs.io/>`_)`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3,7 +3,7 @@ name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -68,7 +68,7 @@ name = "babel"
 version = "2.9.1"
 description = "Internationalization utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
@@ -231,7 +231,7 @@ python-versions = "*"
 
 [[package]]
 name = "docutils"
-version = "0.17.1"
+version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
 optional = false
@@ -341,7 +341,7 @@ name = "imagesize"
 version = "1.2.0"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -658,7 +658,7 @@ name = "pygments"
 version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [[package]]
@@ -765,7 +765,7 @@ name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -839,7 +839,7 @@ name = "sphinx"
 version = "4.0.2"
 description = "Python documentation generator"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -881,11 +881,26 @@ test = ["pytest (>=3.1.0)", "typing-extensions (>=3.5)", "sphobjinv (>=2.0)", "S
 type_comments = ["typed-ast (>=1.4.0)"]
 
 [[package]]
+name = "sphinx-rtd-theme"
+version = "0.5.2"
+description = "Read the Docs theme for Sphinx"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+docutils = "<0.17"
+sphinx = "*"
+
+[package.extras]
+dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -897,7 +912,7 @@ name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -909,7 +924,7 @@ name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.extras]
@@ -921,7 +936,7 @@ name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -943,7 +958,7 @@ name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -955,7 +970,7 @@ name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1171,8 +1186,8 @@ docs = ["sphinx", "sphinx-autodoc-typehints", "numpydoc", "sphinxcontrib-program
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "4396602b3d11cb8ce58b201ebd1d91097590aad3100db2446e9d523e04bb5d8c"
+python-versions = "^3.8"
+content-hash = "bc69c143a80fc372a5b1bd1c9ff0a5b844249558674e75607aaa18e813ff2709"
 
 [metadata.files]
 alabaster = [
@@ -1355,8 +1370,8 @@ distlib = [
     {file = "distlib-0.3.2.zip", hash = "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736"},
 ]
 docutils = [
-    {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
-    {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
+    {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
+    {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
@@ -1824,6 +1839,10 @@ sphinx = [
 sphinx-autodoc-typehints = [
     {file = "sphinx-autodoc-typehints-1.12.0.tar.gz", hash = "sha256:193617d9dbe0847281b1399d369e74e34cd959c82e02c7efde077fca908a9f52"},
     {file = "sphinx_autodoc_typehints-1.12.0-py3-none-any.whl", hash = "sha256:5e81776ec422dd168d688ab60f034fccfafbcd94329e9537712c93003bddc04a"},
+]
+sphinx-rtd-theme = [
+    {file = "sphinx_rtd_theme-0.5.2-py2.py3-none-any.whl", hash = "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"},
+    {file = "sphinx_rtd_theme-0.5.2.tar.gz", hash = "sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 requests = "^2.25.1"
 GitPython = "^3.1.14"
 coloredlogs = "^15.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ template = "news/templates/default.rst"
 
   [[tool.towncrier.type]]
   directory = "removal"
-  name = "Removals and Deprecations"
+  name = "Removals & Deprecations"
   showcontent = true
 
   [[tool.towncrier.type]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,10 @@ sphinx = { version = ">=3.5.1,<5.0.0", optional = true }
 sphinx-autodoc-typehints = { version = "^1.12.0", optional = true }
 sphinxcontrib-programoutput = { version = ">=0.16,<0.18", optional = true }
 numpydoc = { version = "^1.1.0", optional = true }
+sphinx-rtd-theme = { version = "^0.5.2", optional = true }
 
 [tool.poetry.extras]
-docs = ["sphinx", "sphinx-autodoc-typehints", "numpydoc", "sphinxcontrib-programoutput"]
+docs = ["sphinx", "sphinx-autodoc-typehints", "numpydoc", "sphinxcontrib-programoutput", "sphinx-rtd-theme"]
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.13.0"


### PR DESCRIPTION
(fixes #69)

#### Commits

- Test RTD
- Test RTD: added single_source to conf.py
- Test RTD: Python 3.9 -> 3.8
- Test RTD: Python 3.9 -> 3.8
- Test RTD: Python 3.9 -> 3.8 (TypeHints for config.py)
- Test RTD: sphinx_rtd_theme
- Test RTD: typo: sphinx_rtd_theme
- Add Changelog headline
- Modify Changelog headline
- Add the rest of the Changelog entries until 0.1.0
- Changelog note -> warning below 0.5.0
- Chaged towncrier removal name
- Docs: matrixctl.rst -> contributer_documentation
- Add missing newsfragment
