### PR TITLE
SSH: create known_hosts entry, if it does not exist

### DIFF
--- a/matrixctl/handlers/ssh.py
+++ b/matrixctl/handlers/ssh.py
@@ -25,6 +25,7 @@ from getpass import getuser
 from types import TracebackType
 from typing import NamedTuple
 
+from paramiko import AutoAddPolicy
 from paramiko import SSHClient
 from paramiko.channel import ChannelFile
 
@@ -59,6 +60,7 @@ class SSH:
         self.user: str = getuser() if user is None else user
         self.__client: SSHClient = SSHClient()
         self.__client.load_system_host_keys()
+        self.__client.set_missing_host_key_policy(AutoAddPolicy())
         self.__connect()
 
     def __connect(self) -> None:

--- a/news/231.feature
+++ b/news/231.feature
@@ -1,0 +1,1 @@
+``paramiko`` now creates a ``known_hosts`` entry, if it does not exist.


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include documentation and tests.
-->

fixes #231

#### Affected Handlers
<!-- Please provide affected handlers. -->
- VCS

#### Description of Change
<!-- Please provide a description of the change here. -->
- Allow `paramiko` to create a `known_hosts` entry.

#### Checklist
<!-- Only the fields marked with (*) are Mandatory for bugfixes. -->

- [x] Have you documented your changes?
- [x] (*) Have you created an issue first?
- [x] (*) Have you checked to ensure there aren't other open Pull Requests
      for the same update/change?
- [x] (*) Have you created a newsfragment in `./news/`?
- [x] (*) Have you lint your code locally prior to submission?
- [x] (*) Did you ran `tox` and everything passed?
- [x] (*) I haven't added any dependencie without approval.

<!-- [Code of Conduct & Contribution Guidlines](https://matrixctl.rtfd.io/en/latest/contributer_documentation/index.html). -->
I have read and accept the:

- [x] (*) Code of Conduct.
- [x] (*) Contribution Guidelines.
